### PR TITLE
Fix elapsed and remaining time initialization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php-version: '5.6'
+            composer-version: 'v2.2'
+          - php-version: '8.5'
+            composer-version: 'latest'
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer:${{ matrix.composer-version }}
+          coverage: none
+      - run: composer update --no-interaction --prefer-dist --no-progress
+      - run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ for ($i=0; $i < $max; $i++) {
 
 $progressBar->complete();
 ```
+
+Calling `setMaxProgress()` before the first advancement starts the elapsed-time and ETC measurements. If you prepare a progress bar early, call `$progressBar->start()` immediately before processing to reset those measurements explicitly.

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     "php": ">=5.6",
     "khill/php-duration": "^1.0"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^5.7||^9.6"
+  },
   "autoload": {
     "psr-4": {
       "JordJD\\CliProgressBar\\": "./src/"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -19,8 +19,16 @@ class ProgressBar
 
     public function __construct()
     {
+        $this->start();
+    }
+
+    public function start()
+    {
         $this->startTime = time();
         $this->lastProgressAdvancement = microtime(true);
+        $this->advancementTimings = [];
+
+        return $this;
     }
 
     public function setProgress($progress) 
@@ -36,7 +44,11 @@ class ProgressBar
         }
 
         $this->maxProgress = $maxProgress;
-        $this->maxAdvancementTimings = $maxProgress * 0.1;
+        $this->maxAdvancementTimings = max(1, (int) ceil($maxProgress * 0.1));
+
+        if ($this->progress == 0 && count($this->advancementTimings) == 0) {
+            $this->start();
+        }
 
         return $this;
     }

--- a/tests/ProgressBarTest.php
+++ b/tests/ProgressBarTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace JordJD\CliProgressBar\Tests;
+
+use JordJD\CliProgressBar\ProgressBar;
+use PHPUnit\Framework\TestCase;
+
+class ProgressBarTest extends TestCase
+{
+    public function testSettingInitialMaximumStartsTiming()
+    {
+        $progressBar = new ProgressBar();
+        $this->setProperty($progressBar, 'startTime', 0);
+
+        $before = time();
+        $result = $progressBar->setMaxProgress(100);
+
+        $this->assertSame($progressBar, $result);
+        $this->assertGreaterThanOrEqual($before, $this->getProperty($progressBar, 'startTime'));
+    }
+
+    public function testStartResetsTimingSamples()
+    {
+        $progressBar = new ProgressBar();
+        $this->setProperty($progressBar, 'advancementTimings', [10]);
+        $this->setProperty($progressBar, 'startTime', 0);
+
+        $result = $progressBar->start();
+
+        $this->assertSame($progressBar, $result);
+        $this->assertSame([], $this->getProperty($progressBar, 'advancementTimings'));
+        $this->assertGreaterThan(0, $this->getProperty($progressBar, 'startTime'));
+    }
+
+    public function testSmallProgressBarsKeepAtLeastOneTimingSample()
+    {
+        $progressBar = new ProgressBar();
+        $progressBar->setMaxProgress(2)->advance();
+
+        $this->assertCount(1, $this->getProperty($progressBar, 'advancementTimings'));
+    }
+
+    private function getProperty($object, $propertyName)
+    {
+        $property = new \ReflectionProperty($object, $propertyName);
+        $property->setAccessible(true);
+
+        return $property->getValue($object);
+    }
+
+    private function setProperty($object, $propertyName, $value)
+    {
+        $property = new \ReflectionProperty($object, $propertyName);
+        $property->setAccessible(true);
+        $property->setValue($object, $value);
+    }
+}


### PR DESCRIPTION
## Summary

- start elapsed and remaining-time measurements when the initial maximum is configured
- add an explicit start method for progress bars prepared ahead of processing
- keep at least one timing sample for small progress bars
- add PHP 5.6 and PHP 8.5 test coverage

Resolves #1.